### PR TITLE
Dash crashing: Ignore debug_inspector

### DIFF
--- a/app/pages/discharges/discharges.py
+++ b/app/pages/discharges/discharges.py
@@ -103,6 +103,6 @@ def layout() -> dash.html.Div:
     return html.Div(
         children=[
             body,
-            debug_inspector,
+            # debug_inspector,
         ]
     )


### PR DESCRIPTION
For some reason the `debug_inspector` causes Dash to become psychotic, perhaps as there is no data plugged in? Unsure what it is supposed to do.

If not utilised Dash works much more smoothly, and loads correctly with the nav button being used.